### PR TITLE
choose tokio as an optional async runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ readme = "README.md"
 [dependencies]
 futures = "0.3.4"
 async-trait = "0.1.24"
-async-std = { version = "1.5.0", features = ["attributes"] }
+async-std = { version = "1.5.0", features = ["attributes"], optional = true }
+tokio = { version = "0.2", features = ["rt-threaded", "macros", "blocking", "time"], optional = true }
 once_cell = "1.3.1"
 anyhow = "1.0.26"
 xactor-derive = { path = "xactor-derive", version = "0.2.0"}
@@ -26,3 +27,9 @@ fnv = "1.0.6"
 members = [
     "xactor-derive"
 ]
+
+[features]
+runtime-tokio = ["tokio"]
+runtime-async-std = ["async-std"]
+
+default = ["runtime-async-std"]

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -1,7 +1,7 @@
 use crate::addr::ActorEvent;
+use crate::runtime::spawn;
 use crate::system::System;
 use crate::{Addr, Context};
-use async_std::task;
 use futures::channel::mpsc::UnboundedReceiver;
 use futures::lock::Mutex;
 use futures::StreamExt;
@@ -127,7 +127,7 @@ pub(crate) async fn start_actor<A: Actor>(
     // Call started
     actor.lock().await.started(&ctx).await;
 
-    task::spawn({
+    spawn({
         async move {
             while let Some(event) = rx.next().await {
                 match event {

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,7 +1,7 @@
 use crate::addr::ActorEvent;
 use crate::broker::{Subscribe, Unsubscribe};
+use crate::runtime::{sleep, spawn};
 use crate::{Addr, Broker, Error, Handler, Message, Result, Service, StreamHandler};
-use async_std::task;
 use futures::channel::mpsc;
 use futures::{Stream, StreamExt};
 use once_cell::sync::OnceCell;
@@ -111,7 +111,7 @@ impl<A> Context<A> {
         A: StreamHandler<S::Item>,
     {
         let mut addr = self.addr.clone();
-        task::spawn(async move {
+        spawn(async move {
             addr.tx
                 .start_send(ActorEvent::Exec(Box::new(move |actor, ctx| {
                     Box::pin(async move {
@@ -153,8 +153,8 @@ impl<A> Context<A> {
         T: Message<Result = ()>,
     {
         let mut addr = self.addr.clone();
-        task::spawn(async move {
-            task::sleep(after).await;
+        spawn(async move {
+            sleep(after).await;
             addr.send(msg).ok();
         });
     }
@@ -168,9 +168,9 @@ impl<A> Context<A> {
         T: Message<Result = ()>,
     {
         let mut addr = self.addr.clone();
-        task::spawn(async move {
+        spawn(async move {
             loop {
-                task::sleep(dur).await;
+                sleep(dur).await;
                 if let Err(_) = addr.send(f()) {
                     break;
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@ mod addr;
 mod broker;
 mod caller;
 mod context;
+mod runtime;
 mod service;
 mod supervisor;
 mod system;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,0 +1,13 @@
+#![allow(unused_imports)]
+
+#[cfg(not(any(feature = "runtime-tokio", feature = "runtime-async-std")))]
+compile_error!("one of 'runtime-async-std' or 'runtime-tokio' features must be enabled");
+
+#[cfg(all(feature = "runtime-tokio", feature = "runtime-async-std"))]
+compile_error!("only one of 'runtime-async-std' or 'runtime-tokio' features must be enabled");
+
+#[cfg(feature = "runtime-async-std")]
+pub(crate) use async_std::{future::timeout, task::sleep, task::spawn};
+
+#[cfg(feature = "runtime-tokio")]
+pub(crate) use tokio::{task::spawn, time::delay_for as sleep, time::timeout};

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -1,7 +1,7 @@
 use crate::addr::ActorEvent;
+use crate::runtime::spawn;
 use crate::system::System;
 use crate::{Actor, Addr, Context};
-use async_std::task;
 use futures::lock::Mutex;
 use futures::StreamExt;
 use std::sync::Arc;
@@ -89,7 +89,7 @@ impl Supervisor {
         // Call started
         actor.lock().await.started(&ctx).await;
 
-        task::spawn({
+        spawn({
             async move {
                 loop {
                     while let Some(event) = rx.next().await {

--- a/xactor-derive/src/lib.rs
+++ b/xactor-derive/src/lib.rs
@@ -92,9 +92,19 @@ pub fn main(_args: TokenStream, input: TokenStream) -> TokenStream {
                 xactor::System::wait_all().await;
             }
 
-            async_std::task::block_on(async {
-                main().await
-            })
+            #[cfg(feature = "runtime-async-std")]
+            {
+                async_std::task::block_on(async {
+                    main().await
+                })
+            }
+
+            #[cfg(feature = "runtime-tokio")]
+            {
+                tokio::task::spawn_blocking(move || async {
+                    main().await
+                });
+            }
         }
     };
     expanded.into()


### PR DESCRIPTION
Hey,

This patch allows to choose Tokio as an alternative async runtime using feature flags. The default runtime is async-std (feature  =`runtime-async-std`) but can be switched to Tokio using the `runtime-tokio` flag.  Locally I patched all doc tests to use Tokio instead and they pass. I haven't changed any of the tests in this patch because I don't know how to write runtime agnostic doc tests.

I'm not sure if you're interested in such a change to `xactor`. If you are I could maybe look into making the tests apply for both async runtimes and update the pull request.

Best,