### PR TITLE
Add Installation part on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,29 @@ async fn main() -> Result<()> {
 
 [GitHub repository](https://github.com/sunli829/xactor-benchmarks)
 
+## Installation
+
+Xactor require `async-trait` on useland
+
+With [cargo add][cargo-add] installed run:
+
+```sh
+$ cargo add xactor
+$ cargo add async-trait
+```
+
+We also provide a set of "tokio-runtime" features instead of async-std. 
+to use it you need activate feautre: `runtime-tokio` and desable default.
+
+You can edit your `Cargo.toml` has following:
+```
+xactor = { version = "x.x.x", features = ["runtime-tokio"], default-features = false }
+```
+
+[cargo-add]: https://github.com/killercup/cargo-edit
+
 ## References
 
 * [Actix](https://github.com/actix/actix)
 * [Async-std](https://github.com/async-rs/async-std)
+* [Tokio](https://github.com/tokio-rs/tokio)


### PR DESCRIPTION
After some mistake to install has well xactor, 
i thinks a part to explain how installing them can be usefull. 
- default requirement 
- how switch runtime to tokio

My English is not really good, I hope my change is clean.