### PR TITLE
Removed Sender &self mutable reference

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -24,7 +24,7 @@ impl Handler<Die> for MyActor {
 }
 
 #[xactor::main]
-async fn main() -> Result<()>{
+async fn main() -> Result<()> {
     // Exit the program after 3 seconds
     let addr = MyActor.start().await?;
     addr.wait_for_stop().await;

--- a/examples/subscriber.rs
+++ b/examples/subscriber.rs
@@ -1,0 +1,175 @@
+use std::time::Duration;
+use xactor::*;
+
+// This is a basic subscriber example to demonstrate usage of Sender
+// We have actor A - SubscriberParent, manages a vec of child subscribers and in this example, sets up the message producer
+// Actor B - (Child) Subscriber
+// Actor C - Message Producer (Being subscribed to by the child subscribers) - producing a RandomMessage every few seconds to be broadcast to subscribers
+
+#[xactor::main]
+async fn main() -> std::io::Result<()> {
+    let parent_addr = SubscriberParent::new().await.start().await.unwrap();
+    parent_addr.wait_for_stop().await;
+    Ok(())
+}
+
+// Subscriber Parent - A
+
+struct SubscriberParent {
+    children_subscribers: Vec<Addr<Subscriber>>,
+    message_producer: Addr<MessageProducer>,
+}
+
+impl SubscriberParent {
+    async fn new() -> SubscriberParent {
+        SubscriberParent {
+            children_subscribers: Vec::new(),
+            message_producer: MessageProducer::new().start().await.unwrap(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Actor for SubscriberParent {
+    async fn started(&mut self, ctx: &Context<Self>) -> Result<()> {
+        println!("Subscriber Parent Started");
+        let _ = ctx.address().send(InitializeChildSubscribers);
+        Ok(())
+    }
+}
+
+#[message]
+struct InitializeChildSubscribers;
+
+#[async_trait::async_trait]
+impl Handler<InitializeChildSubscribers> for SubscriberParent {
+    async fn handle(&mut self, _ctx: &Context<Self>, _msg: InitializeChildSubscribers) {
+        let message_producer_addr = self.message_producer.clone();
+        let dummy_ids: Vec<i32> = vec![1, 2, 3, 4, 5];
+        let children_unstarted_actors_vec = dummy_ids.into_iter().map(move |id| {
+            let id = id.clone();
+            let addr = message_producer_addr.clone();
+
+            Subscriber::new(id, addr)
+        });
+
+        let children_addr_vec = children_unstarted_actors_vec
+            .into_iter()
+            .map(|actor| async { actor.start().await.unwrap() });
+
+        let children_addr_vec = futures::future::join_all(children_addr_vec).await;
+
+        self.children_subscribers = children_addr_vec;
+    }
+}
+
+#[message]
+struct ClearChildSubscribers;
+
+#[async_trait::async_trait]
+impl Handler<ClearChildSubscribers> for SubscriberParent {
+    async fn handle(&mut self, _ctx: &Context<Self>, _msg: ClearChildSubscribers) {
+        self.children_subscribers = Vec::new();
+    }
+}
+
+// (Child) Subscriber - B
+
+struct Subscriber {
+    id: i32,
+    message_producer_addr: Addr<MessageProducer>,
+}
+
+impl Subscriber {
+    fn new(id: i32, message_producer_addr: Addr<MessageProducer>) -> Subscriber {
+        Subscriber {
+            id,
+            message_producer_addr,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Actor for Subscriber {
+    async fn started(&mut self, ctx: &Context<Self>) -> Result<()> {
+        // Send subscription request message to the Message Producer
+        println!("Child Subscriber Started - id {:?}", self.id);
+        let self_sender = ctx.address().sender();
+        let _ = self.message_producer_addr.send(SubscribeToProducer {
+            sender: self_sender,
+        });
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl Handler<RandomMessage> for Subscriber {
+    async fn handle(&mut self, _ctx: &Context<Self>, msg: RandomMessage) {
+        // We just print out the random id, along with the actor's unique id
+        println!(
+            "Child Subscriber (id: {:?}) Handling RandomMessage body: {:?}",
+            self.id, msg.0
+        );
+    }
+}
+
+// Message Producer - C
+
+struct MessageProducer {
+    subscribers: Vec<Sender<RandomMessage>>,
+}
+
+impl MessageProducer {
+    fn new() -> MessageProducer {
+        MessageProducer {
+            subscribers: Vec::new(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Actor for MessageProducer {
+    async fn started(&mut self, ctx: &Context<Self>) -> Result<()> {
+        // Send broadcast message to self every 2 seconds
+        println!("Message Producer Started");
+        ctx.send_interval(Broadcast, Duration::from_secs(2));
+        Ok(())
+    }
+}
+
+#[message]
+struct SubscribeToProducer {
+    sender: Sender<RandomMessage>,
+}
+
+#[message]
+#[derive(Clone)]
+struct Broadcast;
+
+#[message]
+#[derive(Clone)]
+struct RandomMessage(i32);
+
+#[async_trait::async_trait]
+impl Handler<Broadcast> for MessageProducer {
+    async fn handle(&mut self, _ctx: &Context<Self>, _msg: Broadcast) {
+        // Generate random number and broadcast that message to all subscribers
+        println!("Broadcasting");
+        // To avoid bringing in rand package for the sake of this example, we are hardcoding the "random" number
+        let random_int: i32 = 20;
+        let broadcast_message = RandomMessage(random_int);
+        let _: Vec<_> = self
+            .subscribers
+            .iter()
+            .map(|subscriber| subscriber.send(broadcast_message.clone()))
+            .collect();
+    }
+}
+
+#[async_trait::async_trait]
+impl Handler<SubscribeToProducer> for MessageProducer {
+    async fn handle(&mut self, _ctx: &Context<Self>, msg: SubscribeToProducer) {
+        println!("Recieved Subscription Request");
+        self.subscribers.push(msg.sender);
+    }
+}

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -1,12 +1,12 @@
 use crate::addr::ActorEvent;
 use crate::runtime::spawn;
 use crate::{Addr, Context};
+use anyhow::Result;
 use futures::channel::mpsc::UnboundedReceiver;
 use futures::channel::oneshot;
 use futures::lock::Mutex;
 use futures::{FutureExt, StreamExt};
 use std::sync::Arc;
-use anyhow::Result;
 
 /// Represents a message that can be handled by the actor.
 pub trait Message: 'static + Send {
@@ -116,7 +116,7 @@ pub trait Actor: Sized + Send + 'static {
     }
 }
 
-pub(crate) async fn start_actor<A: Actor> (
+pub(crate) async fn start_actor<A: Actor>(
     ctx: Arc<Context<A>>,
     mut rx: UnboundedReceiver<ActorEvent<A>>,
     tx_exit: oneshot::Sender<()>,

--- a/src/caller.rs
+++ b/src/caller.rs
@@ -13,7 +13,7 @@ pub(crate) type SenderFn<T> = Box<dyn Fn(T) -> Result<()> + 'static + Send>;
 pub struct Caller<T: Message>(pub(crate) CallerFn<T>);
 
 impl<T: Message> Caller<T> {
-    pub async fn call(&mut self, msg: T) -> Result<T::Result> {
+    pub async fn call(&self, msg: T) -> Result<T::Result> {
         self.0(msg).await
     }
 }
@@ -22,7 +22,7 @@ impl<T: Message> Caller<T> {
 pub struct Sender<T: Message>(pub(crate) SenderFn<T>);
 
 impl<T: Message<Result = ()>> Sender<T> {
-    pub fn send(&mut self, msg: T) -> Result<()> {
+    pub fn send(&self, msg: T) -> Result<()> {
         self.0(msg)
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,5 +1,6 @@
 use crate::actor::start_actor;
 use crate::{Actor, Addr, Context};
+use anyhow::Result;
 use fnv::FnvHasher;
 use futures::channel::oneshot;
 use futures::lock::Mutex;
@@ -9,7 +10,6 @@ use std::any::{Any, TypeId};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
-use anyhow::Result;
 
 /// Trait define a global service.
 ///

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -1,10 +1,10 @@
 use crate::addr::ActorEvent;
 use crate::runtime::spawn;
 use crate::{Actor, Addr, Context};
+use anyhow::Result;
 use futures::lock::Mutex;
 use futures::StreamExt;
 use std::sync::Arc;
-use anyhow::Result;
 
 /// Actor supervisor
 ///


### PR DESCRIPTION
Hi @sunli829 

Many thanks for this project (and async-graphql!) - I have been using them together after running into issues with actix and have been finding it much nicer to learn and work with in my refactoring to use xactor.

I have found a couple issues I am happy to try and help with, the first of which is this: 

It doesn't seem like Caller/Sender needs a mutable reference to self in the call/send methods, and this prevents it from being immutably borrowed in cases like the one below.

```Rust
async fn broadcast(&mut self, msg: MessageToBroadcast) {
    let subscribers: Vec<Sender<MessageToBroadcast>> = self.subscribers;
    let _: Vec<_> = subscribers
        .iter()
        .map(|sender| sender.send(msg.clone()))
        .collect();
}
```

Currently there isn't a clone method for Sender either so you can't clone in the closure and then send? 

Rust is quite new to me though so I could be completely wrong and missing something.

I added an example of how to create a simple subscriber pattern that uses this change. 

I also ran `cargo fmt` across the repo to ensure formatting consistency in my example - explains the formatting changes on the other files. 

The other issues I have run into so far are:

- Actors not being stopped on all references to Addr being dropped - I have created an example repo here: https://github.com/jracollins/xactor-issue-example
- No clone, eq functions for sender (makes it impossible to "unsubscribe" in the example currently)

Shall I create individual issues on the xactor repo? 