### PR TITLE
Changed handler context to mutable

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -17,7 +17,7 @@ impl Actor for MyActor {
 
 #[async_trait::async_trait]
 impl Handler<Die> for MyActor {
-    async fn handle(&mut self, ctx: &Context<Self>, _msg: Die) {
+    async fn handle(&mut self, ctx: &mut Context<Self>, _msg: Die) {
         // Stop the actor without error
         ctx.stop(None);
     }

--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -15,7 +15,7 @@ impl Actor for MyActor {}
 /// Handler for `Ping` message
 #[async_trait::async_trait]
 impl Handler<Ping> for MyActor {
-    async fn handle(&mut self, _ctx: &Context<Self>, msg: Ping) -> usize {
+    async fn handle(&mut self, _ctx: &mut Context<Self>, msg: Ping) -> usize {
         self.count += msg.0;
         self.count
     }

--- a/examples/subscriber.rs
+++ b/examples/subscriber.rs
@@ -43,7 +43,7 @@ struct InitializeChildSubscribers;
 
 #[async_trait::async_trait]
 impl Handler<InitializeChildSubscribers> for SubscriberParent {
-    async fn handle(&mut self, _ctx: &Context<Self>, _msg: InitializeChildSubscribers) {
+    async fn handle(&mut self, _ctx: &mut Context<Self>, _msg: InitializeChildSubscribers) {
         let message_producer_addr = self.message_producer.clone();
         let dummy_ids: Vec<i32> = vec![1, 2, 3, 4, 5];
         let children_unstarted_actors_vec = dummy_ids.into_iter().map(move |id| {
@@ -68,7 +68,7 @@ struct ClearChildSubscribers;
 
 #[async_trait::async_trait]
 impl Handler<ClearChildSubscribers> for SubscriberParent {
-    async fn handle(&mut self, _ctx: &Context<Self>, _msg: ClearChildSubscribers) {
+    async fn handle(&mut self, _ctx: &mut Context<Self>, _msg: ClearChildSubscribers) {
         self.children_subscribers = Vec::new();
     }
 }
@@ -104,7 +104,7 @@ impl Actor for Subscriber {
 
 #[async_trait::async_trait]
 impl Handler<RandomMessage> for Subscriber {
-    async fn handle(&mut self, _ctx: &Context<Self>, msg: RandomMessage) {
+    async fn handle(&mut self, _ctx: &mut Context<Self>, msg: RandomMessage) {
         // We just print out the random id, along with the actor's unique id
         println!(
             "Child Subscriber (id: {:?}) Handling RandomMessage body: {:?}",
@@ -152,7 +152,7 @@ struct RandomMessage(i32);
 
 #[async_trait::async_trait]
 impl Handler<Broadcast> for MessageProducer {
-    async fn handle(&mut self, _ctx: &Context<Self>, _msg: Broadcast) {
+    async fn handle(&mut self, _ctx: &mut Context<Self>, _msg: Broadcast) {
         // Generate random number and broadcast that message to all subscribers
         println!("Broadcasting");
         // To avoid bringing in rand package for the sake of this example, we are hardcoding the "random" number
@@ -168,7 +168,7 @@ impl Handler<Broadcast> for MessageProducer {
 
 #[async_trait::async_trait]
 impl Handler<SubscribeToProducer> for MessageProducer {
-    async fn handle(&mut self, _ctx: &Context<Self>, msg: SubscribeToProducer) {
+    async fn handle(&mut self, _ctx: &mut Context<Self>, msg: SubscribeToProducer) {
         println!("Recieved Subscription Request");
         self.subscribers.push(msg.sender);
     }

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -19,7 +19,7 @@ pub trait Message: 'static + Send {
 #[async_trait::async_trait]
 pub trait Handler<T: Message>: Actor {
     /// Method is called for every message received by this Actor.
-    async fn handle(&mut self, ctx: &Context<Self>, msg: T) -> T::Result;
+    async fn handle(&mut self, ctx: &mut Context<Self>, msg: T) -> T::Result;
 }
 
 /// Describes how to handle messages of a specific type.
@@ -30,15 +30,15 @@ pub trait Handler<T: Message>: Actor {
 #[allow(unused_variables)]
 pub trait StreamHandler<T: 'static>: Actor {
     /// Method is called for every message received by this Actor.
-    async fn handle(&mut self, ctx: &Context<Self>, msg: T);
+    async fn handle(&mut self, ctx: &mut Context<Self>, msg: T);
 
     /// Method is called when stream get polled first time.
-    async fn started(&mut self, ctx: &Context<Self>) {}
+    async fn started(&mut self, ctx: &mut Context<Self>) {}
 
     /// Method is called when stream finishes.
     ///
     /// By default this method stops actor execution.
-    async fn finished(&mut self, ctx: &Context<Self>) {
+    async fn finished(&mut self, ctx: &mut Context<Self>) {
         ctx.stop(None);
     }
 }
@@ -89,7 +89,7 @@ pub trait Actor: Sized + Send + 'static {
     ///
     /// #[async_trait::async_trait]
     /// impl Handler<MyMsg> for MyActor {
-    ///     async fn handle(&mut self, _ctx: &Context<Self>, msg: MyMsg) -> i32 {
+    ///     async fn handle(&mut self, _ctx: &mut Context<Self>, msg: MyMsg) -> i32 {
     ///         msg.0 * msg.0
     ///     }
     /// }

--- a/src/broker.rs
+++ b/src/broker.rs
@@ -56,14 +56,14 @@ impl<T: Message<Result = ()> + Clone> Message for Publish<T> {
 ///
 /// #[async_trait::async_trait]
 /// impl Handler<MyMsg> for MyActor {
-///     async fn handle(&mut self, _ctx: &Context<Self>, msg: MyMsg) {
+///     async fn handle(&mut self, _ctx: &mut Context<Self>, msg: MyMsg) {
 ///         self.0 += msg.0;
 ///     }
 /// }
 ///
 /// #[async_trait::async_trait]
 /// impl Handler<GetValue> for MyActor {
-///     async fn handle(&mut self, _ctx: &Context<Self>, _msg: GetValue) -> String {
+///     async fn handle(&mut self, _ctx: &mut Context<Self>, _msg: GetValue) -> String {
 ///         self.0.clone()
 ///     }
 /// }
@@ -103,21 +103,21 @@ impl<T: Message<Result = ()>> Service for Broker<T> {}
 
 #[async_trait::async_trait]
 impl<T: Message<Result = ()>> Handler<Subscribe<T>> for Broker<T> {
-    async fn handle(&mut self, _ctx: &Context<Self>, msg: Subscribe<T>) {
+    async fn handle(&mut self, _ctx: &mut Context<Self>, msg: Subscribe<T>) {
         self.subscribes.insert(msg.id, Box::new(msg.sender));
     }
 }
 
 #[async_trait::async_trait]
 impl<T: Message<Result = ()>> Handler<Unsubscribe> for Broker<T> {
-    async fn handle(&mut self, _ctx: &Context<Self>, msg: Unsubscribe) {
+    async fn handle(&mut self, _ctx: &mut Context<Self>, msg: Unsubscribe) {
         self.subscribes.remove(&msg.id);
     }
 }
 
 #[async_trait::async_trait]
 impl<T: Message<Result = ()> + Clone> Handler<Publish<T>> for Broker<T> {
-    async fn handle(&mut self, _ctx: &Context<Self>, msg: Publish<T>) {
+    async fn handle(&mut self, _ctx: &mut Context<Self>, msg: Publish<T>) {
         for sender in self.subscribes.values_mut() {
             if let Some(sender) = sender.downcast_mut::<Sender<T>>() {
                 sender.send(msg.0.clone()).ok();

--- a/src/context.rs
+++ b/src/context.rs
@@ -88,22 +88,22 @@ impl<A> Context<A> {
     ///
     /// #[async_trait::async_trait]
     /// impl StreamHandler<i32> for MyActor {
-    ///     async fn handle(&mut self, _ctx: &Context<Self>, msg: i32) {
+    ///     async fn handle(&mut self, _ctx: &mut Context<Self>, msg: i32) {
     ///         self.0 += msg;
     ///     }
     ///
-    ///     async fn started(&mut self, _ctx: &Context<Self>) {
+    ///     async fn started(&mut self, _ctx: &mut Context<Self>) {
     ///         println!("stream started");
     ///     }
     ///
-    ///     async fn finished(&mut self, _ctx: &Context<Self>) {
+    ///     async fn finished(&mut self, _ctx: &mut Context<Self>) {
     ///         println!("stream finished");
     ///     }
     /// }
     ///
     /// #[async_trait::async_trait]
     /// impl Handler<GetSum> for MyActor {
-    ///     async fn handle(&mut self, _ctx: &Context<Self>, _msg: GetSum) -> i32 {
+    ///     async fn handle(&mut self, _ctx: &mut Context<Self>, _msg: GetSum) -> i32 {
     ///         self.0
     ///     }
     /// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //!
 //! #[async_trait::async_trait]
 //! impl Handler<ToUppercase> for MyActor {
-//!     async fn handle(&mut self, _ctx: &Context<Self>, msg: ToUppercase) -> String {
+//!     async fn handle(&mut self, _ctx: &mut Context<Self>, msg: ToUppercase) -> String {
 //!         msg.0.to_uppercase()
 //!     }
 //! }

--- a/src/service.rs
+++ b/src/service.rs
@@ -33,7 +33,7 @@ use std::hash::BuildHasherDefault;
 ///
 /// #[async_trait::async_trait]
 /// impl Handler<AddMsg> for MyService {
-///     async fn handle(&mut self, ctx: &Context<Self>, msg: AddMsg) -> i32 {
+///     async fn handle(&mut self, ctx: &mut Context<Self>, msg: AddMsg) -> i32 {
 ///         self.0 += msg.0;
 ///         self.0
 ///     }

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -34,21 +34,21 @@ impl Supervisor {
     ///
     /// #[async_trait::async_trait]
     /// impl Handler<Add> for MyActor {
-    ///     async fn handle(&mut self, ctx: &Context<Self>, _: Add) {
+    ///     async fn handle(&mut self, ctx: &mut Context<Self>, _: Add) {
     ///         self.0 += 1;
     ///     }
     /// }
     ///
     /// #[async_trait::async_trait]
     /// impl Handler<Get> for MyActor {
-    ///     async fn handle(&mut self, ctx: &Context<Self>, _: Get) -> i32 {
+    ///     async fn handle(&mut self, ctx: &mut Context<Self>, _: Get) -> i32 {
     ///         self.0
     ///     }
     /// }
     ///
     /// #[async_trait::async_trait]
     /// impl Handler<Die> for MyActor {
-    ///     async fn handle(&mut self, ctx: &Context<Self>, _: Die) {
+    ///     async fn handle(&mut self, ctx: &mut Context<Self>, _: Die) {
     ///         ctx.stop(None);
     ///     }
     /// }


### PR DESCRIPTION
Hi again 👋 

I just pulled in the changes from https://github.com/sunli829/xactor/commit/d03996f5fd8dbaf92a5786985b847dacbdaea662 and noticed that adding a stream to the context no longer works in a message handler as the `ctx` param is not mutable but `add_stream` now is https://github.com/sunli829/xactor/commit/d03996f5fd8dbaf92a5786985b847dacbdaea662#diff-e0934bb6f70a4f8c3baf22a773c14ec7R130: 

```Rust
error[E0596]: cannot borrow `*ctx` as mutable, as it is behind a `&` reference
   --> src/websocket/mod.rs:111:17
    |
111 |                 ctx.add_stream(read);
    |                 ^^^ `ctx` is a `&` reference, so the data it refers to cannot be borrowed as mutable

```

This is preventing any streams being added outside the started function from what I can see?  

I have changed the others just for consistency. 

As an aside - I have changes in progress for changing the `Sender` and `Caller` functions to no longer have a strong reference to the Addr, so that the actors can be stopped when they are "subscribed" to another actor. Would you prefer to have the senders/callers to have a strong reference by default and instead have a WeakSender/Caller structs? 
