### PR TITLE
Added WeakAddr, updated Caller<T> and Sender<T> to weak references

### DIFF
--- a/src/actor.rs
+++ b/src/actor.rs
@@ -17,7 +17,10 @@ pub trait Message: 'static + Send {
 /// Implementing Handler is a general way to handle incoming messages.
 /// The type T is a message which can be handled by the actor.
 #[async_trait::async_trait]
-pub trait Handler<T: Message>: Actor {
+pub trait Handler<T: Message>: Actor
+where
+    Self: std::marker::Sized,
+{
     /// Method is called for every message received by this Actor.
     async fn handle(&mut self, ctx: &mut Context<Self>, msg: T) -> T::Result;
 }

--- a/src/caller.rs
+++ b/src/caller.rs
@@ -1,28 +1,67 @@
 use crate::{Message, Result};
 use std::future::Future;
+use std::hash::{Hash, Hasher};
 use std::pin::Pin;
 
 pub(crate) type CallerFn<T> = Box<
     dyn Fn(T) -> Pin<Box<dyn Future<Output = Result<<T as Message>::Result>> + Send + 'static>>
+        + Send
         + 'static,
 >;
 
 pub(crate) type SenderFn<T> = Box<dyn Fn(T) -> Result<()> + 'static + Send>;
 
 /// Caller of a specific message type
-pub struct Caller<T: Message>(pub(crate) CallerFn<T>);
+///
+/// Like `Sender<T>, Caller has a weak reference to the recipient of the message type, and so will not prevent an actor from stopping if all Addr's have been dropped elsewhere.
+
+pub struct Caller<T: Message> {
+    pub actor_id: u64,
+    pub(crate) caller_fn: CallerFn<T>,
+}
 
 impl<T: Message> Caller<T> {
     pub async fn call(&self, msg: T) -> Result<T::Result> {
-        self.0(msg).await
+        (self.caller_fn)(msg).await
+    }
+}
+
+impl<T: Message<Result = ()>> PartialEq for Caller<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.actor_id == other.actor_id
+    }
+}
+
+impl<T: Message<Result = ()>> Hash for Caller<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.actor_id.hash(state)
     }
 }
 
 /// Sender of a specific message type
-pub struct Sender<T: Message>(pub(crate) SenderFn<T>);
+///
+/// Like `Caller<T>, Sender has a weak reference to the recipient of the message type, and so will not prevent an actor from stopping if all Addr's have been dropped elsewhere.
+/// This allows it to be used in `send_later` `send_interval` actor functions, and not keep the actor alive indefinitely even after all references to it have been dropped (unless `ctx.stop()` is called from within)
+
+pub struct Sender<T: Message> {
+    pub actor_id: u64,
+    pub(crate) sender_fn: SenderFn<T>,
+}
 
 impl<T: Message<Result = ()>> Sender<T> {
     pub fn send(&self, msg: T) -> Result<()> {
-        self.0(msg)
+        (self.sender_fn)(msg)
+    }
+}
+
+impl<T: Message<Result = ()>> PartialEq for Sender<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.actor_id == other.actor_id
+    }
+}
+
+impl<T: Message<Result = ()>> Hash for Sender<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.actor_id.hash(state)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ pub type Result<T> = anyhow::Result<T>;
 pub type Error = anyhow::Error;
 
 pub use actor::{Actor, Handler, Message, StreamHandler};
-pub use addr::Addr;
+pub use addr::{Addr, WeakAddr};
 pub use broker::Broker;
 pub use caller::{Caller, Sender};
 pub use context::Context;


### PR DESCRIPTION
Hello again! 👋 

I have finally tidied up a hacked version I have been using myself that implements the following: 

-  I have created a `WeakAddr<A>` that can be downgraded from and upgraded to `Addr<A>` - this lets an actor be referenced/send messages to in multiple locations, but "managed" in places with a strong reference.
-  I have changed `Sender` and `Caller` to also use a weak reference to the `Addr` mpsc channel, rather than a clone of the `Addr`, so that when the `Addr`'s are dropped, the actor will be stopped, even if there is still a `Sender`/`Caller` to it. 

This fixes an issue I encountered, where an interval would prevent the actor from ever stopping/being dropped. This also facilitates parent/child actor communication without having circular `Addr` references.
 
This could potentially be changed to have a `WeakSender`/`WeakCaller`, and then the interval functions would need changing/have variants (eg `weak_send_later`) made for the use case of self lifetime managing actors? (eg: an Actor that is just created, `Addr` is not held anywhere, and runs until it calls `ctx.stop()` itself?) - what are your thoughts on this? 

I'm not sure how to implement `clone()` for `Sender`/`Caller` though? - It would be quite helpful to be able to pass around if you have any ideas. 
 
Let me know your thoughts and I can make changes from there. 
