### PR TITLE
clean up intervals and timeouts

### DIFF
--- a/examples/supervisor_clear_interval.rs
+++ b/examples/supervisor_clear_interval.rs
@@ -1,0 +1,87 @@
+use std::time::{Duration, Instant};
+use xactor::{message, Actor, Context, Handler};
+
+#[derive(Debug)]
+pub struct PingTimer {
+    last_ping: Instant,
+}
+
+impl Default for PingTimer {
+    fn default() -> Self {
+        PingTimer {
+            last_ping: Instant::now(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Actor for PingTimer {
+    async fn started(&mut self, ctx: &mut Context<Self>) -> xactor::Result<()> {
+        println!("PingTimer:: started()");
+        ctx.send_interval(Ping, Duration::from_millis(1000));
+        Ok(())
+    }
+
+    /// Called after an actor is stopped.
+    async fn stopped(&mut self, _: &mut Context<Self>) {
+        println!("PingTimer:: stopped()");
+    }
+}
+
+#[message]
+#[derive(Clone)]
+struct Ping;
+
+#[async_trait::async_trait]
+impl Handler<Ping> for PingTimer {
+    async fn handle(&mut self, ctx: &mut Context<Self>, _msg: Ping) {
+        let now = Instant::now();
+        let delta = (now - self.last_ping).as_millis();
+        self.last_ping = now;
+        println!("PingTimer:: Ping {} {:?}", ctx.actor_id(), delta);
+    }
+}
+#[message]
+struct Halt;
+
+#[async_trait::async_trait]
+impl Handler<Halt> for PingTimer {
+    async fn handle(&mut self, ctx: &mut Context<Self>, _msg: Halt) {
+        println!("PingTimer:: received Halt");
+        ctx.stop(None);
+        println!("PingTimer:: stopped");
+    }
+}
+
+#[message]
+struct Panic;
+
+#[async_trait::async_trait]
+impl Handler<Panic> for PingTimer {
+    async fn handle(&mut self, _: &mut Context<Self>, _msg: Panic) {
+        println!("PingTimer:: received Panic");
+        panic!("intentional panic");
+    }
+}
+
+#[xactor::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let service_supervisor = xactor::Supervisor::start(PingTimer::default).await?;
+    let service_addr = service_supervisor.clone();
+
+    let supervisor_task = xactor::spawn(async {
+        service_supervisor.wait_for_stop().await;
+    });
+
+    let send_halt = async {
+        xactor::sleep(Duration::from_millis(5_200)).await;
+        println!("  main  :: sending Halt");
+        service_addr.send(Halt).unwrap();
+    };
+
+    futures::join!(supervisor_task, send_halt);
+    // run this to see that the interval is not properly stopped if the ctx is stopped
+    // futures::join!(supervisor_task, send_panic); // there is no panic recovery
+
+    Ok(())
+}

--- a/examples/supervisor_clear_send_later.rs
+++ b/examples/supervisor_clear_send_later.rs
@@ -1,0 +1,65 @@
+use std::time::Duration;
+use xactor::{message, Actor, Context, Handler};
+
+#[derive(Debug, Default)]
+pub struct PingLater;
+
+#[async_trait::async_trait]
+impl Actor for PingLater {
+    async fn started(&mut self, ctx: &mut Context<Self>) -> xactor::Result<()> {
+        ctx.send_later(Ping("after halt"), Duration::from_millis(1_500));
+
+        Ok(())
+    }
+    /// Called after an actor is stopped.
+    async fn stopped(&mut self, _: &mut Context<Self>) {
+        println!("PingLater:: stopped()");
+    }
+}
+
+#[message]
+#[derive(Debug)]
+struct Ping(&'static str);
+
+#[async_trait::async_trait]
+impl Handler<Ping> for PingLater {
+    async fn handle(&mut self, _ctx: &mut Context<Self>, msg: Ping) {
+        println!("PingLater:: handle {:?}", msg);
+    }
+}
+#[message]
+struct Halt;
+
+#[async_trait::async_trait]
+impl Handler<Halt> for PingLater {
+    async fn handle(&mut self, ctx: &mut Context<Self>, _msg: Halt) {
+        println!("PingLater:: received Halt");
+        ctx.stop(None);
+        println!("PingLater:: stopped");
+    }
+}
+
+#[xactor::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let service_supervisor = xactor::Supervisor::start(PingLater::default).await?;
+    let service_addr = service_supervisor.clone();
+
+    let supervisor_task = xactor::spawn(async {
+        service_supervisor.wait_for_stop().await;
+    });
+
+    let send_ping = async {
+        println!("  main  :: sending Ping");
+        service_addr.send(Ping("before halt")).unwrap();
+    };
+
+    let send_halt = async {
+        xactor::sleep(Duration::from_millis(1_000)).await;
+        println!("  main  :: sending Halt");
+        service_addr.send(Halt).unwrap();
+    };
+
+    futures::join!(supervisor_task, send_halt, send_ping);
+
+    Ok(())
+}

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -167,9 +167,8 @@ impl<A: Actor> ActorManager<A> {
 
                 actor.stopped(&mut ctx).await;
 
-                for (_, handle) in ctx.streams.iter() {
-                    handle.abort();
-                }
+                ctx.abort_streams();
+                ctx.abort_intervals();
 
                 tx_exit.send(()).ok();
             }

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -105,11 +105,15 @@ impl Supervisor {
                     }
 
                     actor.stopped(&mut ctx).await;
+                    ctx.abort_streams();
+                    ctx.abort_intervals();
+
                     actor = f();
                     actor.started(&mut ctx).await.ok();
                 }
-
                 actor.stopped(&mut ctx).await;
+                ctx.abort_streams();
+                ctx.abort_intervals();
             }
         });
 


### PR DESCRIPTION
Hi there!
I took a little time to think about #29 again and tried to build a demonstrator.
If you check out badc0de and run `cargo run --example supervisor_clear_interval` it will print the following, indicating that after the actor's context was stopped and restarted by the `Supervisor` suddenly the interval is running twice.

```
 ● xactor  cargo run --example supervisor_clear_interval                                          feature/interval_cleanup* [20:34:29]
   Compiling xactor v0.7.9 (/Users/hendrik/code/rust/hub/xactor)
    Finished dev [unoptimized + debuginfo] target(s) in 1.30s
     Running `target/debug/examples/supervisor_clear_interval`
PingTimer:: started()
PingTimer:: Ping 0 1004
PingTimer:: Ping 0 1002
PingTimer:: Ping 0 1005
PingTimer:: Ping 0 1002
PingTimer:: Ping 0 1002
  main  :: sending Halt
PingTimer:: received Halt
PingTimer:: stopped
PingTimer:: stopped()
PingTimer:: started()
PingTimer:: Ping 0 814     /// <-- these should be ~1000
PingTimer:: Ping 0 186
PingTimer:: Ping 0 816
PingTimer:: Ping 0 188
PingTimer:: Ping 0 814
PingTimer:: Ping 0 185
```

The demonstrator prints the time between the last two pings.

Similarly the second demonstrator in badc0de shows that a `send_later` timeout is not canceled and therefore send twice after the restart:

```
cargo run --example supervisor_clear_send_later                                        feature/interval_cleanup* [20:34:28]
   Compiling xactor v0.7.9 (/Users/hendrik/code/rust/hub/xactor)
    Finished dev [unoptimized + debuginfo] target(s) in 2.01s
     Running `target/debug/examples/supervisor_clear_send_later`
  main  :: sending Ping
PingLater:: handle Ping("before halt")
  main  :: sending Halt
PingLater:: received Halt
PingLater:: stopped
PingLater:: stopped()
PingLater:: handle Ping("after halt")
PingLater:: handle Ping("after halt")      /// <-- this shouldn't be here a second time
```

In the subsequent commit c0ffeea this should be fixed by aborting all intervals and timeouts when an `Actor` or `Supervisor` is stopped.

Have a nice day.