### PR TITLE
Adding an Eyre feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,12 @@ jobs:
       - name: Build with async-std
         run: cargo build --all --verbose
       - name: Build with tokio
-        run: cargo build --all --features runtime-tokio --no-default-features --verbose
+        run: cargo build --all --features runtime-tokio anyhow --no-default-features --verbose
+      - name: Build with eyre
+        run: cargo build --all --features runtime-tokio eyre --no-default-features --verbose
       - name: Run tests with async-std
         run: cargo test --all --verbose
       - name: Run tests with tokio
-        run: cargo test --all --verbose --features runtime-tokio --no-default-features --verbose
+        run: cargo test --all --verbose --features runtime-tokio anyhow --no-default-features --verbose
+      - name: Run tests with eyre
+        run: cargo test --all --verbose --features runtime-tokio eyre --no-default-features --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,12 @@ jobs:
       - name: Build with async-std
         run: cargo build --all --verbose
       - name: Build with tokio
-        run: cargo build --all --features runtime-tokio anyhow --no-default-features --verbose
+        run: cargo build --all --features "runtime-tokio anyhow" --no-default-features --verbose
       - name: Build with eyre
-        run: cargo build --all --features runtime-tokio eyre --no-default-features --verbose
+        run: cargo build --all --features "runtime-tokio eyre" --no-default-features --verbose
       - name: Run tests with async-std
         run: cargo test --all --verbose
       - name: Run tests with tokio
-        run: cargo test --all --verbose --features runtime-tokio anyhow --no-default-features --verbose
+        run: cargo test --all --verbose --features "runtime-tokio anyhow" --no-default-features --verbose
       - name: Run tests with eyre
-        run: cargo test --all --verbose --features runtime-tokio eyre --no-default-features --verbose
+        run: cargo test --all --verbose --features "runtime-tokio eyre" --no-default-features --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,11 @@ async-trait = "0.1.42"
 async-std = { version = "1.8.0", features = ["attributes"], optional = true }
 tokio = { version = "1.0.1", features = ["rt-multi-thread", "macros", "time"], optional = true }
 once_cell = "1.5.2"
-anyhow = "1.0.37"
 xactor-derive = { path = "xactor-derive", version = "0.7"}
 fnv = "1.0.7"
 slab = "0.4.2"
+anyhow = { version = "1.0.37", optional = true }
+eyre = { version = "0.6.5", optional = true }
 
 [workspace]
 members = [
@@ -33,4 +34,4 @@ members = [
 runtime-tokio = ["tokio"]
 runtime-async-std = ["async-std"]
 
-default = ["runtime-async-std"]
+default = ["runtime-async-std", "anyhow"]

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -1,7 +1,7 @@
 use crate::addr::ActorEvent;
 use crate::runtime::spawn;
 use crate::{Addr, Context};
-use anyhow::Result;
+use crate::error::Result;
 use futures::channel::mpsc::{UnboundedReceiver, UnboundedSender};
 use futures::channel::oneshot;
 use futures::{FutureExt, StreamExt};

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -130,7 +130,7 @@ impl<A: Actor> Addr<A> {
                             ))?;
                             Ok(oneshot_rx.await?)
                         }
-                        None => Err(anyhow::anyhow!("Actor Dropped")),
+                        None => Err(crate::error::anyhow!("Actor Dropped")),
                     }
                 })
             })),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,12 @@ mod runtime;
 mod service;
 mod supervisor;
 
+#[cfg(all(feature = "anyhow", feature = "eyre"))]
+compile_error!(r#"
+    features `xactor/anyhow` and `xactor/eyre` are mutually exclusive.
+    If you are trying to disable anyhow set `default-features = false`.
+"#);
+
 #[cfg(feature="anyhow")]
 pub use anyhow as error;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,11 +71,17 @@ mod runtime;
 mod service;
 mod supervisor;
 
-/// Alias of anyhow::Result
-pub type Result<T> = anyhow::Result<T>;
+#[cfg(feature="anyhow")]
+pub use anyhow as error;
 
-/// Alias of anyhow::Error
-pub type Error = anyhow::Error;
+#[cfg(feature="eyre")]
+pub use eyre as error;
+
+/// Alias of error::Result
+pub type Result<T> = error::Result<T>;
+
+/// Alias of error::Error
+pub type Error = error::Error;
 
 pub type ActorId = u64;
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,6 +1,6 @@
 use crate::actor::ActorManager;
 use crate::{Actor, Addr};
-use anyhow::Result;
+use crate::error::Result;
 use fnv::FnvHasher;
 use futures::lock::Mutex;
 use once_cell::sync::OnceCell;

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -1,7 +1,7 @@
 use crate::addr::ActorEvent;
 use crate::runtime::spawn;
 use crate::{Actor, Addr, Context};
-use anyhow::Result;
+use crate::error::Result;
 use futures::StreamExt;
 
 /// Actor supervisor


### PR DESCRIPTION
I recently switched my project to [Eyre](https://crates.io/crates/eyre) for it's [tracing](https://crates.io/crates/tracing) integration (and wow, is it ever an improvement!). This PR adds features so that application developers can choose between either Eyre or Anyhow.

For library developers Eyre exports most of the same interface as Anyhow and error-lib agnostic code can be written for xactor by using the common interfaces of Anyhow/Eyre via `xactor::error`.