### PR TITLE
Customizable actor message queue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,5 @@ members = [
 [features]
 runtime-tokio = ["tokio"]
 runtime-async-std = ["async-std"]
-
+generic-mailbox = []
 default = ["runtime-async-std", "anyhow"]

--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ You can edit your `Cargo.toml` as follows:
 xactor = { version = "x.x.x", features = ["runtime-tokio"], default-features = false }
 ```
 
+On **Nightly compilers** from after 2021-08-04, there is also the option to use a user-defined class as the underlying message queue using the `generic-mailbox` feature. This does not affect or require default features.
+
+```toml
+xactor = { version = "x.x.x", features = ["generic-mailbox"] }
+```
+
+
 [cargo-add]: https://github.com/killercup/cargo-edit
 
 ## References

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+#![cfg_attr(feature = "generic-mailbox", feature(associated_type_defaults))] // For back compatibility even if the feature's on
+#![cfg_attr(feature = "generic-mailbox", feature(associated_type_bounds))]
+#![cfg_attr(feature = "generic-mailbox", feature(generic_associated_types))]
+
 //! # Xactor is a rust actors framework based on async-std
 //!
 //! ## Documentation
@@ -67,6 +71,7 @@ mod addr;
 mod broker;
 mod caller;
 mod context;
+mod mailbox;
 mod runtime;
 mod service;
 mod supervisor;
@@ -96,6 +101,8 @@ pub use addr::{Addr, WeakAddr};
 pub use broker::Broker;
 pub use caller::{Caller, Sender};
 pub use context::Context;
+#[allow(unused_imports)]
+pub use mailbox::*; // Contents changes depending on feature gates, so glob avoids naming pontentially non-existing items
 pub use runtime::{block_on, sleep, spawn, timeout};
 pub use service::{LocalService, Service};
 pub use supervisor::Supervisor;

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -1,0 +1,86 @@
+#[cfg(feature = "generic-mailbox")]
+mod mailbox {
+    // This module really exists to group everything under the feature
+    use futures::channel::mpsc;
+    use futures::{Sink, Stream};
+
+    /// Marker trait representing containers usable as the message queue of an [`Actor`](crate::actor::Actor)
+    ///
+    /// The underlying message type is kept private as an implementation detail, so the implementing types must be generic over `T : Send`
+    pub trait MessageQueue {
+        type Tx<T: Send>: MessageSender<T>;
+        type Rx<T: Send>: MessageReceiver<T>;
+
+        /// Create a linked pair [`MessageSender`] and [`MessageReceiver`]
+        fn create<T: Send>() -> (Self::Tx<T>, Self::Rx<T>);
+    }
+
+    pub trait MessageSender<T>:
+        Clone + Send + Sync + Sink<T, Error = <Self as MessageSender<T>>::Error> + Unpin
+    where
+        T: Send,
+    {
+        type Error: std::error::Error + Sync + Send;
+    }
+
+    pub trait MessageReceiver<T>: Send + Sync + Stream<Item = T> + Unpin
+    where
+        T: Send,
+    {
+    }
+
+    /// Default Mailbox, implemented by an [unbounded queue](futures::channel::mpsc::unbounded)
+    ///
+    /// This was also the original behaviour in previous versions of this crate.
+    pub struct UnboundedMailbox;
+
+    impl MessageQueue for UnboundedMailbox {
+        type Tx<A: Send> = mpsc::UnboundedSender<A>;
+        type Rx<B: Send> = mpsc::UnboundedReceiver<B>;
+        fn create<T>() -> (mpsc::UnboundedSender<T>, mpsc::UnboundedReceiver<T>) {
+            mpsc::unbounded()
+        }
+    }
+    impl<T: Send> MessageSender<T> for mpsc::UnboundedSender<T> {
+        type Error = mpsc::SendError;
+    }
+    impl<T: Send> MessageReceiver<T> for mpsc::UnboundedReceiver<T> {}
+
+    /// Same as the default [UnboundedMailbox], except that there is a bounded number of items, with sends potentially blocking.
+    /// See [mpsc::channel] for details.
+    pub struct BoundedMailbox<const BUFFER: usize> {}
+
+    impl<const BUFFER: usize> MessageQueue for BoundedMailbox<BUFFER> {
+        type Tx<A: Send> = mpsc::Sender<A>;
+        type Rx<B: Send> = mpsc::Receiver<B>;
+        fn create<T>() -> (mpsc::Sender<T>, mpsc::Receiver<T>) {
+            mpsc::channel(BUFFER)
+        }
+    }
+    impl<T: Send> MessageSender<T> for mpsc::Sender<T> {
+        type Error = mpsc::SendError;
+    }
+    impl<T: Send> MessageReceiver<T> for mpsc::Receiver<T> {}
+}
+
+#[cfg(feature = "generic-mailbox")]
+pub use mailbox::*;
+#[cfg(feature = "generic-mailbox")]
+mod mailbox_private {
+    // Need to have a separate module because the use::* would expose these publicly
+    use super::mailbox::*;
+    use crate::addr::ActorEvent;
+    use crate::Actor;
+    pub(crate) type EventReceiver<A> = <<A as Actor>::Mailbox as MessageQueue>::Rx<ActorEvent<A>>;
+    pub(crate) type EventSender<A> = <<A as Actor>::Mailbox as MessageQueue>::Tx<ActorEvent<A>>;
+}
+
+#[cfg(not(feature = "generic-mailbox"))]
+mod mailbox_private {
+    use crate::addr::ActorEvent;
+    use futures::channel::mpsc::*;
+    pub(crate) type EventReceiver<A> = UnboundedReceiver<ActorEvent<A>>;
+    pub(crate) type EventSender<A> = UnboundedSender<ActorEvent<A>>;
+}
+
+pub(crate) use mailbox_private::{EventReceiver, EventSender};


### PR DESCRIPTION
While using xactor to build an IRC server, I realized that I wanted a different implementation for actors' message queues, so that they would respond to backpressure from other parts of my system. I thought others might have the same problem and appreciate a solution, so I have designed my change to be general and allow the implementor to pick their own type as needed. 

This PR replaces the hardcoded `Sender` and `Receiver` types the Actor uses to queue messages with a set of associated types that allow for any queue implementation that implements the appropriate traits. However, that queue uses the internal `ActorEvent` type, and I did not want to expose that unnecessarily. To work around this, I use GATs, so this is only available on Nightly for now. If it is acceptable for `ActorEvent` to be exposed publicly, even completely opaquely, **this would be doable on stable.**

I have tried to maintain backwards compatibility by feature-gating and providing defaults so that existing uses will continue exactly working as before even with the feature switched on. The only change I'm aware of that is not gated and immediately backwards compatible is that I had to explicitly constrain the generic parameter for `Context`, `Addr` and the like to be an `Actor`, but I couldn't see how it would be possible to use anything else as that parameter, so I don't think there's any possible breakage. 


Let me know any feedback you have or changes you'd like made. 