### PR TITLE
Cloning Senders & Callers, Memory leak fix, return Aborthandle for intervals, various fixes & dependency updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "xactor"
 version = "0.7.11"
 authors = ["sunli <scott_s829@163.com>"]
 description = "Xactor is a rust actors framework based on async-std"
-edition = "2018"
+edition = "2021"
 publish = true
 license = "MIT"
 documentation = "https://docs.rs/xactor/"
@@ -14,16 +14,17 @@ categories = ["network-programming", "asynchronous"]
 readme = "README.md"
 
 [dependencies]
-futures = "0.3.8"
-async-trait = "0.1.42"
-async-std = { version = "1.8.0", features = ["attributes"], optional = true }
-tokio = { version = "1.0.1", features = ["rt-multi-thread", "macros", "time"], optional = true }
-once_cell = "1.5.2"
-xactor-derive = { path = "xactor-derive", version = "0.7"}
+futures = "0.3.21"
+async-trait = "0.1.52"
+async-std = { version = "1.10.0", features = ["attributes"], optional = true }
+tokio = { version = "1.17.0", features = ["rt-multi-thread", "macros", "time"], optional = true }
+once_cell = "1.9.0"
+xactor-derive = { path = "xactor-derive", version = "0.7" }
 fnv = "1.0.7"
-slab = "0.4.2"
-anyhow = { version = "1.0.37", optional = true }
-eyre = { version = "0.6.5", optional = true }
+slab = "0.4.5"
+anyhow = { version = "1.0.53", optional = true }
+eyre = { version = "0.6.6", optional = true }
+dyn-clone = "1.0.4"
 
 [workspace]
 members = [

--- a/examples/intervals.rs
+++ b/examples/intervals.rs
@@ -1,0 +1,31 @@
+use std::time::Duration;
+use xactor::*;
+
+#[message]
+struct IntervalMsg;
+
+struct MyActor;
+
+#[async_trait::async_trait]
+impl Actor for MyActor {
+    async fn started(&mut self, ctx: &mut Context<Self>) -> Result<()> {
+        // Send the IntervalMsg message 3 seconds later
+        ctx.send_later(IntervalMsg, Duration::from_millis(500));
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl Handler<IntervalMsg> for MyActor {
+    async fn handle(&mut self, ctx: &mut Context<Self>, _msg: IntervalMsg) {
+        ctx.send_later(IntervalMsg, Duration::from_millis(500));
+    }
+}
+
+#[xactor::main]
+async fn main() -> Result<()> {
+    // Exit the program after 3 seconds
+    let addr = MyActor.start().await?;
+    addr.wait_for_stop().await;
+    Ok(())
+}

--- a/examples/subscriber.rs
+++ b/examples/subscriber.rs
@@ -95,9 +95,21 @@ impl Actor for Subscriber {
         // Send subscription request message to the Message Producer
         println!("Child Subscriber Started - id {:?}", self.id);
         let self_sender = ctx.address().sender();
+
         let _ = self.message_producer_addr.send(SubscribeToProducer {
-            sender: self_sender,
+            sender: self_sender.clone(),
         });
+
+        let _ = self.message_producer_addr.send(SubscribeToProducer {
+            sender: self_sender.clone(),
+        });
+        let _ = self.message_producer_addr.send(SubscribeToProducer {
+            sender: self_sender.clone(),
+        });
+        let _ = self.message_producer_addr.send(SubscribeToProducer {
+            sender: self_sender.clone(),
+        });
+
         Ok(())
     }
 }
@@ -169,7 +181,7 @@ impl Handler<Broadcast> for MessageProducer {
 #[async_trait::async_trait]
 impl Handler<SubscribeToProducer> for MessageProducer {
     async fn handle(&mut self, _ctx: &mut Context<Self>, msg: SubscribeToProducer) {
-        println!("Recieved Subscription Request");
+        println!("Recieved Subscription Request {:}", msg.sender.actor_id);
         self.subscribers.push(msg.sender);
     }
 }

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -1,7 +1,7 @@
 use crate::addr::ActorEvent;
+use crate::error::Result;
 use crate::runtime::spawn;
 use crate::{Addr, Context};
-use crate::error::Result;
 use futures::channel::mpsc::{UnboundedReceiver, UnboundedSender};
 use futures::channel::oneshot;
 use futures::{FutureExt, StreamExt};
@@ -158,8 +158,10 @@ impl<A: Actor> ActorManager<A> {
                         ActorEvent::Exec(f) => f(&mut actor, &mut ctx).await,
                         ActorEvent::Stop(_err) => break,
                         ActorEvent::RemoveStream(id) => {
-                            if ctx.streams.contains(id) {
-                                ctx.streams.remove(id);
+                            let mut streams = ctx.streams.lock().unwrap();
+
+                            if streams.contains(id) {
+                                streams.remove(id);
                             }
                         }
                     }

--- a/src/broker.rs
+++ b/src/broker.rs
@@ -1,14 +1,9 @@
-use crate::{Actor, Addr, Context, Handler, Message, Result, Sender, Service};
+use crate::{Actor, ActorId, Addr, Context, Handler, Message, Result, Sender, Service};
 use fnv::FnvHasher;
-use std::any::Any;
-use std::collections::HashMap;
-use std::hash::BuildHasherDefault;
-use std::marker::PhantomData;
-
-type SubscriptionId = u64;
+use std::{collections::HashMap, hash::BuildHasherDefault};
 
 pub(crate) struct Subscribe<T: Message<Result = ()>> {
-    pub(crate) id: SubscriptionId,
+    pub(crate) actor_id: ActorId,
     pub(crate) sender: Sender<T>,
 }
 
@@ -17,19 +12,12 @@ impl<T: Message<Result = ()>> Message for Subscribe<T> {
 }
 
 pub(crate) struct Unsubscribe {
-    pub(crate) id: SubscriptionId,
+    pub(crate) actor_id: ActorId,
 }
 
 impl Message for Unsubscribe {
     type Result = ();
 }
-
-struct Publish<T: Message<Result = ()> + Clone>(T);
-
-impl<T: Message<Result = ()> + Clone> Message for Publish<T> {
-    type Result = ();
-}
-
 /// Message broker is used to support publishing and subscribing to messages.
 ///
 /// # Examples
@@ -86,15 +74,13 @@ impl<T: Message<Result = ()> + Clone> Message for Publish<T> {
 /// }
 /// ```
 pub struct Broker<T: Message<Result = ()>> {
-    subscribes: HashMap<SubscriptionId, Box<dyn Any + Send>, BuildHasherDefault<FnvHasher>>,
-    mark: PhantomData<T>,
+    subscribers: HashMap<ActorId, Sender<T>, BuildHasherDefault<FnvHasher>>,
 }
 
 impl<T: Message<Result = ()>> Default for Broker<T> {
     fn default() -> Self {
         Self {
-            subscribes: Default::default(),
-            mark: PhantomData,
+            subscribers: Default::default(),
         }
     }
 }
@@ -106,31 +92,29 @@ impl<T: Message<Result = ()>> Service for Broker<T> {}
 #[async_trait::async_trait]
 impl<T: Message<Result = ()>> Handler<Subscribe<T>> for Broker<T> {
     async fn handle(&mut self, _ctx: &mut Context<Self>, msg: Subscribe<T>) {
-        self.subscribes.insert(msg.id, Box::new(msg.sender));
+        self.subscribers.insert(msg.actor_id, msg.sender);
     }
 }
 
 #[async_trait::async_trait]
 impl<T: Message<Result = ()>> Handler<Unsubscribe> for Broker<T> {
     async fn handle(&mut self, _ctx: &mut Context<Self>, msg: Unsubscribe) {
-        self.subscribes.remove(&msg.id);
+        self.subscribers.remove(&msg.actor_id);
     }
 }
 
 #[async_trait::async_trait]
-impl<T: Message<Result = ()> + Clone> Handler<Publish<T>> for Broker<T> {
-    async fn handle(&mut self, _ctx: &mut Context<Self>, msg: Publish<T>) {
-        for sender in self.subscribes.values_mut() {
-            if let Some(sender) = sender.downcast_mut::<Sender<T>>() {
-                sender.send(msg.0.clone()).ok();
-            }
-        }
+impl<T: Message<Result = ()> + Clone> Handler<T> for Broker<T> {
+    async fn handle(&mut self, _ctx: &mut Context<Self>, msg: T) {
+        // Broadcast to all subscribers and remove any senders that return an error (most likely because reciever dropped because actor already stopped)
+        self.subscribers
+            .retain(|_actor_id, sender| sender.send(msg.clone()).is_ok())
     }
 }
 
 impl<T: Message<Result = ()> + Clone> Addr<Broker<T>> {
     /// Publishes a message of the specified type.
     pub fn publish(&mut self, msg: T) -> Result<()> {
-        self.send(Publish(msg))
+        self.send(msg)
     }
 }

--- a/src/caller.rs
+++ b/src/caller.rs
@@ -2,55 +2,57 @@ use crate::{ActorId, Message, Result};
 use std::future::Future;
 use std::hash::{Hash, Hasher};
 use std::pin::Pin;
-use std::sync::Mutex;
-
-pub(crate) type CallerFuture<T> =
-    Pin<Box<dyn Future<Output = Result<<T as Message>::Result>> + Send + 'static>>;
-
-pub(crate) type CallerFn<T> = Box<dyn Fn(T) -> CallerFuture<T> + Send + 'static>;
-
-pub(crate) type SenderFn<T> = Box<dyn Fn(T) -> Result<()> + 'static + Send>;
 
 /// Caller of a specific message type
 ///
-/// Like `Sender<T>, Caller has a weak reference to the recipient of the message type, and so will not prevent an actor from stopping if all Addr's have been dropped elsewhere.
+/// Like `Sender<T>`, Caller has a weak reference to the recipient of the message type, and so will not prevent an actor from stopping if all Addr's have been dropped elsewhere.
+/// This takes a boxed closure with the message as a parameter with the mpsc channel of the actor inside and the type of actor abstracted away.
 
 pub struct Caller<T: Message> {
     pub actor_id: ActorId,
-    pub(crate) caller_fn: Mutex<CallerFn<T>>,
+    pub(crate) caller_fn: Box<dyn CallerFn<T>>,
 }
 
 impl<T: Message> Caller<T> {
-    pub fn call(&self, msg: T) -> CallerFuture<T> {
-        (self.caller_fn.lock().unwrap())(msg)
+    pub async fn call(&self, msg: T) -> Result<T::Result> {
+        self.caller_fn.call(msg).await
     }
 }
 
-impl<T: Message<Result = ()>> PartialEq for Caller<T> {
+impl<T: Message> PartialEq for Caller<T> {
     fn eq(&self, other: &Self) -> bool {
         self.actor_id == other.actor_id
     }
 }
 
-impl<T: Message<Result = ()>> Hash for Caller<T> {
+impl<T: Message> Hash for Caller<T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.actor_id.hash(state)
     }
 }
 
+impl<T: Message> Clone for Caller<T> {
+    fn clone(&self) -> Caller<T> {
+        Caller {
+            actor_id: self.actor_id,
+            caller_fn: dyn_clone::clone_box(&*self.caller_fn),
+        }
+    }
+}
+
 /// Sender of a specific message type
 ///
-/// Like `Caller<T>, Sender has a weak reference to the recipient of the message type, and so will not prevent an actor from stopping if all Addr's have been dropped elsewhere.
+/// Like `Caller<T>`, Sender has a weak reference to the recipient of the message type, and so will not prevent an actor from stopping if all Addr's have been dropped elsewhere.
 /// This allows it to be used in `send_later` `send_interval` actor functions, and not keep the actor alive indefinitely even after all references to it have been dropped (unless `ctx.stop()` is called from within)
 
 pub struct Sender<T: Message> {
     pub actor_id: ActorId,
-    pub(crate) sender_fn: SenderFn<T>,
+    pub(crate) sender_fn: Box<dyn SenderFn<T>>,
 }
 
 impl<T: Message<Result = ()>> Sender<T> {
     pub fn send(&self, msg: T) -> Result<()> {
-        (self.sender_fn)(msg)
+        self.sender_fn.send(msg)
     }
 }
 
@@ -63,5 +65,52 @@ impl<T: Message<Result = ()>> PartialEq for Sender<T> {
 impl<T: Message<Result = ()>> Hash for Sender<T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.actor_id.hash(state)
+    }
+}
+
+impl<T: Message<Result = ()>> Clone for Sender<T> {
+    fn clone(&self) -> Sender<T> {
+        Sender {
+            actor_id: self.actor_id,
+            sender_fn: dyn_clone::clone_box(&*self.sender_fn),
+        }
+    }
+}
+
+// https://stackoverflow.com/questions/63842261/how-to-derive-clone-for-structures-with-boxed-closure
+// https://users.rust-lang.org/t/expected-opaque-type-found-a-different-opaque-type-when-trying-futures-join-all/40596/3
+use dyn_clone::DynClone;
+
+pub trait SenderFn<T>: DynClone + 'static + Send + Sync
+where
+    T: Message,
+{
+    fn send(&self, msg: T) -> Result<()>;
+}
+
+impl<F, T> SenderFn<T> for F
+where
+    F: Fn(T) -> Result<()> + 'static + Send + Sync + Clone,
+    T: Message,
+{
+    fn send(&self, msg: T) -> Result<()> {
+        self(msg)
+    }
+}
+
+pub trait CallerFn<T>: DynClone + 'static + Send + Sync
+where
+    T: Message,
+{
+    fn call(&self, msg: T) -> Pin<Box<dyn Future<Output = Result<T::Result>>>>;
+}
+
+impl<F, T> CallerFn<T> for F
+where
+    F: Fn(T) -> Pin<Box<dyn Future<Output = Result<T::Result>>>> + 'static + Send + Sync + Clone,
+    T: Message,
+{
+    fn call(&self, msg: T) -> Pin<Box<dyn Future<Output = Result<T::Result>>>> {
+        self(msg)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,15 +72,17 @@ mod service;
 mod supervisor;
 
 #[cfg(all(feature = "anyhow", feature = "eyre"))]
-compile_error!(r#"
+compile_error!(
+    r#"
     features `xactor/anyhow` and `xactor/eyre` are mutually exclusive.
     If you are trying to disable anyhow set `default-features = false`.
-"#);
+"#
+);
 
-#[cfg(feature="anyhow")]
+#[cfg(feature = "anyhow")]
 pub use anyhow as error;
 
-#[cfg(feature="eyre")]
+#[cfg(feature = "eyre")]
 pub use eyre as error;
 
 /// Alias of error::Result
@@ -89,7 +91,7 @@ pub type Result<T> = error::Result<T>;
 /// Alias of error::Error
 pub type Error = error::Error;
 
-pub type ActorId = u64;
+pub type ActorId = usize;
 
 pub use actor::{Actor, Handler, Message, StreamHandler};
 pub use addr::{Addr, WeakAddr};

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,6 +1,6 @@
 use crate::actor::ActorManager;
-use crate::{Actor, Addr};
 use crate::error::Result;
+use crate::{Actor, Addr};
 use fnv::FnvHasher;
 use futures::lock::Mutex;
 use once_cell::sync::OnceCell;

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -1,7 +1,7 @@
 use crate::addr::ActorEvent;
+use crate::error::Result;
 use crate::runtime::spawn;
 use crate::{Actor, Addr, Context};
-use crate::error::Result;
 use futures::StreamExt;
 
 /// Actor supervisor
@@ -97,8 +97,10 @@ impl Supervisor {
                             Some(ActorEvent::Stop(_err)) => break 'event_loop,
                             Some(ActorEvent::Exec(f)) => f(&mut actor, &mut ctx).await,
                             Some(ActorEvent::RemoveStream(id)) => {
-                                if ctx.streams.contains(id) {
-                                    ctx.streams.remove(id);
+                                let mut streams = ctx.streams.lock().unwrap();
+
+                                if streams.contains(id) {
+                                    streams.remove(id);
                                 }
                             }
                         }

--- a/xactor-derive/Cargo.toml
+++ b/xactor-derive/Cargo.toml
@@ -16,6 +16,6 @@ categories = ["network-programming", "asynchronous"]
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.6"
-syn = { version = "1.0.13", features = ["full"] }
-quote = "1.0.2"
+proc-macro2 = "1.0.36"
+syn = { version = "1.0.86", features = ["full"] }
+quote = "1.0.15"


### PR DESCRIPTION
Hi again @sunli829! 👋  

Apologies for the large individual PR and list of changes - been meaning to create an upstream PR for a while for all of these features/fixes after using in production working off my fork. 

This PR contains the following: 

-   Ability to `Clone` `Senders` & `Callers` using [dynclone](https://github.com/dtolnay/dyn-clone)
    -   Removes wrapping of `CallerFn` in a `Mutex`
-   Adds Docs for Sender/Callers - Resolves #44
-   Small refactor in `Broker` to use remove `Box<dyn Any + Send>` and use `Sender` directly - asked in #44
-   Fixes infinitely growing slab for intervals (was causing OOM issues when using `send_later` repeatedly)
-   Returns `AbortHandle` for `intervals`/`send_later` so that creator can cancel before completion if desired without stopping actor
-   Changes ActorId to use `usize` rather than `u64` - Resolves #41
-   Bumps dependencies to latest versions
-  Added `Eq` to compare Callers/Senders
